### PR TITLE
Fix for RN0.47+

### DIFF
--- a/android/src/main/java/com/zyu/ReactNativeWheelPickerPackage.java
+++ b/android/src/main/java/com/zyu/ReactNativeWheelPickerPackage.java
@@ -20,11 +20,6 @@ public class ReactNativeWheelPickerPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
                 new ReactWheelCurvedPickerManager()


### PR DESCRIPTION
There is a breaking change in RN0.47 as per this stack overflow:
https://stackoverflow.com/questions/45580452/react-native-android-method-does-not-override-or-implement-a-method-from-a-supe

Causes Android build to fail without it. Tested and working after change.