### PR TITLE
Changed createJSModules to support rn 0.47

### DIFF
--- a/android/src/main/java/com/zyu/ReactNativeWheelPickerPackage.java
+++ b/android/src/main/java/com/zyu/ReactNativeWheelPickerPackage.java
@@ -19,7 +19,6 @@ public class ReactNativeWheelPickerPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes react native compatibility on android removing the @Override annotation on createJSModules.

Related to #25 but this one supports backwards compatibility.