### PR TITLE
Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,23 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
+    }
+    lintOptions {
+        abortOnError false
     }
 }
 


### PR DESCRIPTION
Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk